### PR TITLE
Add CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.github  export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install lz4
       run: |
-        set -xe; \
-        BUILD_DIR="/tmp/build/lz4" \
-        mkdir -p "$BUILD_DIR"; \
-        curl -sL https://github.com/lz4/lz4/releases/download/v${{ matrix.lz4 }}/lz4-${{ matrix.lz4 }}.tar.gz | \
-          tar -zx --strip-components=1 -C "$BUILD_DIR"; \
-        cd "$BUILD_DIR"; \
-        ./configure; \
+        set -xe
+        BUILD_DIR="/tmp/build/lz4"
+        mkdir -p "$BUILD_DIR"
+        curl -sL https://github.com/lz4/lz4/releases/download/v${{ matrix.lz4 }}/lz4-${{ matrix.lz4 }}.tar.gz |
+          tar -zx --strip-components=1 -C "$BUILD_DIR"
+        cd "$BUILD_DIR"
+        ./configure
         make && make install
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.3'
-    - name: configure
+    - name: Configure
       run: ./configure
-    - name: make
+    - name: Make
       run: make
-    - name: make test
+    - name: Make test
       run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         set -xe
         BUILD_DIR="/tmp/build/lz4"
         mkdir -p "$BUILD_DIR"
-        curl -sL https://github.com/lz4/lz4/releases/download/v${{ matrix.lz4 }}/lz4-${{ matrix.lz4 }}.tar.gz | \
+        curl -sL https://github.com/lz4/lz4/archive/refs/tags/v${{ matrix.lz4}}.tar.gz | \
           tar -zx --strip-components=1 -C "$BUILD_DIR"
         cd "$BUILD_DIR"
         ./configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
         curl -sL https://github.com/lz4/lz4/archive/refs/tags/v${{ matrix.lz4}}.tar.gz | \
           tar -zx --strip-components=1 -C "$BUILD_DIR"
         cd "$BUILD_DIR"
-        ./configure
         make && make install
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install lz4
       run: sudo apt-get install -y liblz4-dev
     - name: Setup PHP
-      uses: shivammathur/setup-php@2
+      uses: shivammathur/setup-php@v2
       with:
         php-version: '8.3'
     - name: configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,24 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        lz4: ['1.9.2']
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
     - name: Install lz4
-      run: sudo apt-get install -y liblz4-dev
+      run: |
+        set -xe; \
+        BUILD_DIR="/tmp/build/lz4" \
+        mkdir -p "$BUILD_DIR"; \
+        curl -sL https://github.com/lz4/lz4/releases/download/v${{ matrix.lz4 }}/lz4-${{ matrix.lz4 }}.tar.gz | \
+          tar -zx --strip-components=1 -C "$BUILD_DIR"; \
+        cd "$BUILD_DIR"; \
+        ./configure; \
+        make && make install
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         set -xe
         BUILD_DIR="/tmp/build/lz4"
         mkdir -p "$BUILD_DIR"
-        curl -sL https://github.com/lz4/lz4/releases/download/v${{ matrix.lz4 }}/lz4-${{ matrix.lz4 }}.tar.gz |
+        curl -sL https://github.com/lz4/lz4/releases/download/v${{ matrix.lz4 }}/lz4-${{ matrix.lz4 }}.tar.gz | \
           tar -zx --strip-components=1 -C "$BUILD_DIR"
         cd "$BUILD_DIR"
         ./configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
         curl -sL https://github.com/lz4/lz4/archive/refs/tags/v${{ matrix.lz4}}.tar.gz | \
           tar -zx --strip-components=1 -C "$BUILD_DIR"
         cd "$BUILD_DIR"
-        make && make install
+        make
+        sudo make install
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install lz4
+      run: sudo apt-get install -y liblz4-dev
+    - name: Setup PHP
+      uses: shivammathur/setup-php@2
+      with:
+        php-version: '8.3'
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make test
+      run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.3'
+    - name: Phpize
+      run: phpize
     - name: Configure
       run: ./configure
     - name: Make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,12 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
-        lz4: ['1.9.2']
+        os: [ubuntu-latest, ubuntu-20.04]
+        lz4: ['1.9.2', '1.10.0']
 
+    name: ${{ matrix.os }} - lz4 ${{ matrix.lz4 }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-20.04]
+        php: ['8.1', '8.2', '8.3', '8.4']
         lz4: ['1.9.2', '1.10.0']
 
-    name: ${{ matrix.os }} - lz4 ${{ matrix.lz4 }}
+    name: ${{ matrix.os }} - PHP ${{ matrix.php }} - lz4 ${{ matrix.lz4 }}
     runs-on: ubuntu-latest
 
     steps:
@@ -30,7 +31,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.3'
+        php-version: ${{ matrix.php }}
     - name: Phpize
       run: phpize
     - name: Configure

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# LZ4 PHP
+
+[![CI](https://github.com/dew-serverless/php-ext-lz4/actions/workflows/ci.yml/badge.svg)](https://github.com/dew-serverless/php-ext-lz4/actions/workflows/ci.yml)
+
+LZ4 compression for PHP, based on Yann Collet's work available at https://github.com/lz4/lz4.


### PR DESCRIPTION
- Add a simple `README.md`;
- Covers only the Linux operating system, with the minimum required version of _lz4_ and the current latest version;
- Covers currently supported PHP versions: `8.1`, `8.2`, `8.3`, and the upcoming `8.4`;