### PR TITLE
Expose version constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ The constants below are defined by this extension, and will only be available
 when the extension has been dynamically loaded at runtime.
 
 <dl>
-    <dt>LZ4_VERSION (string)</dt>
+    <dt>LZ4_VERSION_STRING (string)</dt>
     <dd>lz4 version number as a string.</dd>
-    <dt>LZ4_VERNUM (int)</dt>
+    <dt>LZ4_VERSION_NUMBER (int)</dt>
     <dd>lz4 version number as an int.</dd>
 </dl>
 

--- a/lz4.c
+++ b/lz4.c
@@ -9,9 +9,6 @@
 #include "php_lz4.h"
 #include "lz4_arginfo.h"
 
-#include <lz4.h>
-#include <lz4hc.h>
-
 /* For compatibility with older PHP versions */
 #ifndef ZEND_PARSE_PARAMETERS_NONE
 #define ZEND_PARSE_PARAMETERS_NONE() \
@@ -190,12 +187,20 @@ PHP_MINFO_FUNCTION(lz4)
 }
 /* }}} */
 
+/* {{{ PHP_MINIT_FUNCTION */
+static PHP_MINIT_FUNCTION(lz4)
+{
+	register_lz4_symbols(module_number);
+	return SUCCESS;
+}
+/* }}} */
+
 /* {{{ lz4_module_entry */
 zend_module_entry lz4_module_entry = {
 	STANDARD_MODULE_HEADER,
 	"lz4",					/* Extension name */
 	ext_functions,			/* zend_function_entry */
-	NULL,					/* PHP_MINIT - Module initialization */
+	PHP_MINIT(lz4),
 	NULL,					/* PHP_MSHUTDOWN - Module shutdown */
 	PHP_RINIT(lz4),			/* PHP_RINIT - Request initialization */
 	NULL,					/* PHP_RSHUTDOWN - Request shutdown */

--- a/lz4.stub.php
+++ b/lz4.stub.php
@@ -5,6 +5,18 @@
  * @undocumentable
  */
 
+ /**
+  * @var int
+  * @cvalue LZ4_VERSION_NUMBER
+  */
+ const LZ4_VERSION_NUMBER = UNKNOWN;
+
+/**
+ * @var string
+ * @cvalue LZ4_VERSION_STRING
+ */
+const LZ4_VERSION_STRING = UNKNOWN;
+
 function lz4compress(string $data, int $level = 0): string|false {}
 
 function lz4uncompress(string $data, int $max_length = 0): string|false {}

--- a/lz4_arginfo.h
+++ b/lz4_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 13f1a14170f436f49d93a915f93f8b6fab87b4c2 */
+ * Stub hash: c3c36bb8d703c74567fea30e200803694abf7e3d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_lz4compress, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
@@ -21,3 +21,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(lz4uncompress, arginfo_lz4uncompress)
 	ZEND_FE_END
 };
+
+static void register_lz4_symbols(int module_number)
+{
+	REGISTER_LONG_CONSTANT("LZ4_VERSION_NUMBER", LZ4_VERSION_NUMBER, CONST_PERSISTENT);
+	REGISTER_STRING_CONSTANT("LZ4_VERSION_STRING", LZ4_VERSION_STRING, CONST_PERSISTENT);
+}

--- a/php_lz4.h
+++ b/php_lz4.h
@@ -1,12 +1,12 @@
 /* lz4 extension for PHP */
 
 #ifndef PHP_LZ4_H
-# define PHP_LZ4_H
+#define PHP_LZ4_H
 
-extern zend_module_entry lz4_module_entry;
-# define phpext_lz4_ptr &lz4_module_entry
+#include <lz4.h>
+#include <lz4hc.h>
 
-# define PHP_LZ4_VERSION "0.1.0"
+#define PHP_LZ4_VERSION "0.1.0"
 
 #define PHP_LZ4_OK 0
 #define PHP_LZ4_MEM_ERROR -1
@@ -15,5 +15,8 @@ extern zend_module_entry lz4_module_entry;
 # if defined(ZTS) && defined(COMPILE_DL_LZ4)
 ZEND_TSRMLS_CACHE_EXTERN()
 # endif
+
+extern zend_module_entry lz4_module_entry;
+# define phpext_lz4_ptr &lz4_module_entry
 
 #endif	/* PHP_LZ4_H */

--- a/tests/014.phpt
+++ b/tests/014.phpt
@@ -1,0 +1,12 @@
+--TEST--
+register constants
+--EXTENSIONS--
+lz4
+--FILE--
+<?php
+echo LZ4_VERSION_NUMBER.PHP_EOL;
+echo LZ4_VERSION_STRING.PHP_EOL;
+?>
+--EXPECTF--
+%d
+%d.%d.%d


### PR DESCRIPTION
The final constant names are renamed to:

- LZ4_VERSION_STRING
- LZ4_VERSION_NUMBER

Closes #6.